### PR TITLE
markdown syntax of 'click here' in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,8 +29,8 @@ We love your input! We want to make contributing to this project as easy and tra
 | HTML                           | FreeCodeCamp      | [click here](https://www.youtube.com/watch?v=pQN-pnXPaVg) |
 | Python Basics (Beginner)       | FreeCodeCamp      | [click here](https://www.youtube.com/watch?v=rfscVS0vtbw) |
 | React JS (Beginner to Advance) | Clever Programmer | [click here](https://www.youtube.com/watch?v=-cMqr9HpZ-Y) |
-| Python Tutorial(Beginner)      | Great Learning    | [click here] ( https://youtu.be/RJWlUyfOy1o )             |
-| Excel Tutorial (Beginner)      | Teacher's Tech    | [click here] ( https://youtube.com/playlist?list=PLmkaw6oRnRv8lAKbKbflJRqS-9wuYNWUw )                                                                                                       |
+| Python Tutorial(Beginner)      | Great Learning    | [click here](https://youtu.be/RJWlUyfOy1o)             |
+| Excel Tutorial (Beginner)      | Teacher's Tech    | [click here](https://youtube.com/playlist?list=PLmkaw6oRnRv8lAKbKbflJRqS-9wuYNWUw)                                                                                                       |
 
 
 


### PR DESCRIPTION
fixed markdown syntax of 'click here' CONTRIBUTING.md, eliminated spaces between brackets and parentheses for the format of [text](link)